### PR TITLE
bugfix: quotes for img tags

### DIFF
--- a/activejob/activejob/templates/web/pages/contact.html
+++ b/activejob/activejob/templates/web/pages/contact.html
@@ -13,9 +13,9 @@ mail@activ-job.com</a></p>
 
         <div id="icons">
 
-            <a href="{% url 'unternehmensprofil' %}"  title="ISO 9001:2008"><img style="width: 106px; margin-left: -8px;" alt="ISO 9001:2008" src={% static 'images/iso.png' %}/></a>
-            <a href="{% url 'unternehmensprofil' %}"  title="Geprüfte Nachhaltigkeit 2015"><img alt="Geprüfte Nachhaltigkeit 2015" src={% static 'images/dino.png' %}/></a>
-            <a href="{% url 'leitbild' %}"  title="15 Jahre activjob"><img alt="15 Jahre activjob" src={% static 'images/15_jahre_activjob.png' %}/></a>
+            <a href="{% url 'unternehmensprofil' %}"  title="ISO 9001:2008"><img style="width: 106px; margin-left: -8px;" alt="ISO 9001:2008" src="{% static 'images/iso.png' %}"></a>
+            <a href="{% url 'unternehmensprofil' %}"  title="Geprüfte Nachhaltigkeit 2015"><img alt="Geprüfte Nachhaltigkeit 2015" src="{% static 'images/dino.png' %}"></a>
+            <a href="{% url 'leitbild' %}"  title="15 Jahre activjob"><img alt="15 Jahre activjob" src="{% static 'images/15_jahre_activjob.png' %}"></a>
 
         </div>
 
@@ -31,9 +31,9 @@ mail@activ-job.com</a></p>
         </div>
 
         <div class="feed_n_sm">
-          <a href="{% url 'jobs_rss' %}"><img alt="Stellenmarkt RSS Feed" src={% static 'images/rss.jpg' %} /></a>
-          <a href="http://www.facebook.com/activjob"><img alt="" src={% static 'images/facebook.png' %} /></a>
-          <a href="http://www.zukunft-elite.de/" title="ZUKUNFT | ELITE."><img alt="ZE" src={% static 'images/ZE-Logo-social-29.png' %} /></a>
+          <a href="{% url 'jobs_rss' %}"><img alt="Stellenmarkt RSS Feed" src="{% static 'images/rss.jpg' %}"></a>
+          <a href="http://www.facebook.com/activjob"><img alt="" src="{% static 'images/facebook.png' %}"></a>
+          <a href="http://www.zukunft-elite.de/" title="ZUKUNFT | ELITE."><img alt="ZE" src="{% static 'images/ZE-Logo-social-29.png' %}"></a>
         </div>
 
 


### PR DESCRIPTION
runserver forgives a url like /static/images/iso.png/
that came from <img ... src={% static 'images/iso.png' %}/>
but nginx won't